### PR TITLE
Update dfl-feature-ids.rst

### DIFF
--- a/dfl-feature-ids.rst
+++ b/dfl-feature-ids.rst
@@ -98,6 +98,10 @@ document.
      - 0
      - 0x20
 
+   * - n5010 Hitek MAC
+     - 0
+     - 0x21
+
    * - Port Errors
      - 1
      - 0x10


### PR DESCRIPTION
The N5010 card has Hitek MAC that connects the FPGA with Columbiaville. The driver for this feature id handles the Hitek MAC.