### PR TITLE
Add missing feature ID: QSPI Flash

### DIFF
--- a/dfl-feature-ids.rst
+++ b/dfl-feature-ids.rst
@@ -46,6 +46,10 @@ document.
      - 0
      - 7
 
+   * - QSPI Flash
+     - 0
+     - 8
+
    * - External Memory Interface (EMIF)
      - 0
      - 9


### PR DESCRIPTION
Add an entry for the QSPI Flash feature ID.

Signed-off-by: Russ Weight <russell.h.weight@intel.com>