### PR TITLE
Reserve ID for feature with a GUID

### DIFF
--- a/dfl-feature-ids.rst
+++ b/dfl-feature-ids.rst
@@ -110,6 +110,10 @@ document.
      - 0
      - 0x22
 
+   * - Feature with GUID
+     - 0
+     - 0x23
+
    * - Port Errors
      - 1
      - 0x10


### PR DESCRIPTION
The Device Feature Header of a private feature may be followed
by a GUID for more precise identification.

Signed-off-by: Matthew Gerlach <matthew.gerlach@linux.intel.com>