### PR TITLE
Add Virtual  UART  DFH feature id

### DIFF
--- a/dfl-feature-ids.rst
+++ b/dfl-feature-ids.rst
@@ -114,6 +114,10 @@ document.
      - 0
      - 0x23
 
+   * - Virtual UART 
+     - 0
+     - 0x24
+
    * - Port Errors
      - 1
      - 0x10


### PR DESCRIPTION
Add Virtual  UART  DFH feature id 0x24

Signed-off-by: anandaravuri <ananda.ravuri@intel.com>