### PR TITLE
Add OFS attribution for HSSI subsystem

### DIFF
--- a/dfl-feature-ids.rst
+++ b/dfl-feature-ids.rst
@@ -90,7 +90,7 @@ document.
      - 0
      - 0x14
 
-   * - HSSI Subsystem
+   * - OFS HSSI Subsystem
      - 0
      - 0x15
 


### PR DESCRIPTION
Adding OFS attribution for HSSI subsystem (0x15).
This is request for linux-fpga community.

Link: https://lore.kernel.org/linux-fpga/20220308064315.1452217-1-tianfei.zhang@intel.com/

Signed-off-by: Tianfei zhang <tianfei.zhang@intel.com>