### PR TITLE
Fix pci subsystem id for N6001

### DIFF
--- a/dfl-pci-ids.rst
+++ b/dfl-pci-ids.rst
@@ -94,5 +94,5 @@ Device Feature Lists (DFL).
 
    * - PCIE_DEVICE_SID_N6001
      - PCI_VENDOR_ID_INTEL 0x8086
-     - 0x17d1
+     - 0x1771
 


### PR DESCRIPTION
Fix the typo in the subsystem id for the N6001 card.

Signed-off-by: Matthew Gerlach <matthew.gerlach@linux.intel.com>